### PR TITLE
Bunch of fixes from several authors. 

### DIFF
--- a/haxelib/aze/display/SparrowTilesheet.hx
+++ b/haxelib/aze/display/SparrowTilesheet.hx
@@ -1,9 +1,9 @@
 package aze.display;
 
-import flash.display.BitmapData;
-import flash.geom.Point;
-import flash.geom.Rectangle;
-import flash.Lib;
+import openfl.display.BitmapData;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
+import openfl.Lib;
 
 /**
 parrow spritesheet parser for TileLayer
@@ -35,8 +35,6 @@ class SparrowTilesheet extends TilesheetEx
 						Std.parseInt(texture.att.frameWidth), Std.parseInt(texture.att.frameHeight));
 				else 
 					new Rectangle(0, 0, rect.width, rect.height);
-			
-			//trace([name, rect.x, rect.y, rect.width, rect.height, size.x, size.y, size.width, size.height]);
 			
 			#if flash
 			var bmp = new BitmapData(cast size.width, cast size.height, true, 0);

--- a/haxelib/aze/display/TileGroup.hx
+++ b/haxelib/aze/display/TileGroup.hx
@@ -3,8 +3,9 @@ package aze.display;
 import aze.display.TileLayer;
 import aze.display.TileGroup;
 import aze.display.TileSprite;
-import flash.display.DisplayObject;
-import flash.display.Sprite;
+
+import openfl.display.DisplayObject;
+import openfl.display.Sprite;
 
 /**
  * Tiles container for TileLayer

--- a/haxelib/aze/display/TileLayer.hx
+++ b/haxelib/aze/display/TileLayer.hx
@@ -90,7 +90,7 @@ class TileLayer extends TileGroup
 			if (!child.visible) continue;
 			#end
 			
-			#if (flash||js)
+			#if (flash || js || neko)
 			var group:TileGroup = Std.is(child, TileGroup) ? cast child : null;
 			#else
 			var group:TileGroup = cast child;
@@ -132,13 +132,8 @@ class TileLayer extends TileGroup
 						list[index] = sprite.x - off.x * t[0] - off.y * t[1] + gx;
 						list[index+1] = sprite.y - off.x * t[2] - off.y * t[3] + gy;
 						list[index+offsetTransform] = t[0];
-						#if js
 						list[index+offsetTransform+1] = t[2];
 						list[index+offsetTransform+2] = t[1];
-						#else
-						list[index+offsetTransform+1] = t[1];
-						list[index+offsetTransform+2] = t[2];
-						#end
 						list[index+offsetTransform+3] = t[3];
 					}
 					else {
@@ -152,13 +147,8 @@ class TileLayer extends TileGroup
 					if (offsetTransform > 0) {
 						var t = sprite.transform;
 						list[index+offsetTransform] = t[0];
-						#if js
 						list[index+offsetTransform+1] = t[2];
 						list[index+offsetTransform+2] = t[1];
-						#else
-						list[index+offsetTransform+1] = t[1];
-						list[index+offsetTransform+2] = t[2];
-						#end
 						list[index+offsetTransform+3] = t[3];
 					}
 				}

--- a/haxelib/aze/display/TileLayer.hx
+++ b/haxelib/aze/display/TileLayer.hx
@@ -1,15 +1,15 @@
 package aze.display;
 
-import flash.geom.Point;
-import flash.display.Bitmap;
-import flash.display.BitmapData;
-import flash.display.BlendMode;
-import flash.display.DisplayObject;
-import flash.display.Graphics;
-import flash.display.Sprite;
-import flash.geom.Matrix;
-import flash.geom.Rectangle;
-import flash.Lib;
+import openfl.display.Bitmap;
+import openfl.display.BitmapData;
+import openfl.display.BlendMode;
+import openfl.display.DisplayObject;
+import openfl.display.Graphics;
+import openfl.display.Sprite;
+import openfl.geom.Matrix;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
+import openfl.Lib;
 
 /**
  * A little wrapper of NME's Tilesheet rendering (for native platform)
@@ -79,7 +79,7 @@ class TileLayer extends TileGroup
 		gx += group.x;
 		gy += group.y;
 		#end
-
+		
 		var n = group.numChildren;
 		for(i in 0...n)
 		{
@@ -90,7 +90,11 @@ class TileLayer extends TileGroup
 			if (!child.visible) continue;
 			#end
 			
+			#if (flash||js)
 			var group:TileGroup = Std.is(child, TileGroup) ? cast child : null;
+			#else
+			var group:TileGroup = cast child;
+			#end
 
 			if (group != null) 
 			{
@@ -101,10 +105,11 @@ class TileLayer extends TileGroup
 				var sprite:TileSprite = cast child;
 
 				#if flash
-				if (sprite.visible && sprite.alpha > 0.0)
+				if (sprite.parent.visible && sprite.visible && sprite.alpha > 0.0)
 				{
 					var m = sprite.bmp.transform.matrix;
 					m.identity();
+					if (sprite.offset != null) m.translate(-sprite.offset.x, -sprite.offset.y);
 					m.concat(sprite.matrix);
 					m.translate(sprite.x, sprite.y);
 					sprite.bmp.transform.matrix = m;
@@ -118,17 +123,22 @@ class TileLayer extends TileGroup
 				#else
 				if (sprite.alpha <= 0.0) continue;
 				list[index+2] = sprite.indice;
-
+				
 				if (sprite.offset != null) 
 				{
-					var off:Point = sprite.offset;					
+					var off:Point = sprite.offset;
 					if (offsetTransform > 0) {
 						var t = sprite.transform;
-						list[index] = sprite.x - off.x * t[0] - off.y * t[2] + gx;
-						list[index+1] = sprite.y - off.x * t[1] - off.y * t[3] + gy;
+						list[index] = sprite.x - off.x * t[0] - off.y * t[1] + gx;
+						list[index+1] = sprite.y - off.x * t[2] - off.y * t[3] + gy;
 						list[index+offsetTransform] = t[0];
+						#if js
+						list[index+offsetTransform+1] = t[2];
+						list[index+offsetTransform+2] = t[1];
+						#else
 						list[index+offsetTransform+1] = t[1];
 						list[index+offsetTransform+2] = t[2];
+						#end
 						list[index+offsetTransform+3] = t[3];
 					}
 					else {
@@ -142,12 +152,17 @@ class TileLayer extends TileGroup
 					if (offsetTransform > 0) {
 						var t = sprite.transform;
 						list[index+offsetTransform] = t[0];
+						#if js
+						list[index+offsetTransform+1] = t[2];
+						list[index+offsetTransform+2] = t[1];
+						#else
 						list[index+offsetTransform+1] = t[1];
 						list[index+offsetTransform+2] = t[2];
+						#end
 						list[index+offsetTransform+3] = t[3];
 					}
 				}
-
+				
 				if (offsetRGB > 0) {
 					list[index+offsetRGB] = sprite.r;
 					list[index+offsetRGB+1] = sprite.g;
@@ -167,7 +182,6 @@ class TileLayer extends TileGroup
 /**
  * @private base tile type
  */
-
 class TileBase
 {
 	public var layer:TileLayer;
@@ -177,14 +191,14 @@ class TileBase
 	public var animated:Bool;
 	public var visible:Bool;
 
-	function new(layer:TileLayer)
+	public function new(layer:TileLayer)
 	{
 		this.layer = layer;
 		x = y = 0.0;
 		visible = true;
 	}
 
-	function init(layer:TileLayer):Void
+	public function init(layer:TileLayer):Void
 	{
 		this.layer = layer;
 	}
@@ -194,7 +208,7 @@ class TileBase
 	}
 
 	#if flash
-	function getView():DisplayObject { return null; }
+	public function getView():DisplayObject { return null; }
 	#end
 }
 
@@ -202,11 +216,7 @@ class TileBase
 /**
  * @private render buffer
  */
-#if haxe3
-	class DrawList
-#else
-	class DrawList implements Public
-#end
+private class DrawList
 {
 	public var list:Array<Float>;
 	public var index:Int;
@@ -219,22 +229,14 @@ class TileBase
 	public var elapsed:Int;
 	public var runs:Int;
 
-	#if haxe3
-		public function new() 
-	#else
-		function new() 
-	#end
+	public function new() 
 	{
 		list = new Array<Float>();
 		elapsed = 0;
 		runs = 0;
 	}
 
-	#if haxe3
-		public function begin(elapsed:Int, useTransforms:Bool, useAlpha:Bool, useTint:Bool, useAdditive:Bool) 
-	#else
-		function begin(elapsed:Int, useTransforms:Bool, useAlpha:Bool, useTint:Bool, useAdditive:Bool) 
-	#end
+	public function begin(elapsed:Int, useTransforms:Bool, useAlpha:Bool, useTint:Bool, useAdditive:Bool) 
 	{
 		#if !flash
 		flags = 0;

--- a/haxelib/aze/display/TileSprite.hx
+++ b/haxelib/aze/display/TileSprite.hx
@@ -1,11 +1,12 @@
 package aze.display;
 
 import aze.display.TileLayer;
-import flash.geom.Matrix;
-import flash.display.Bitmap;
-import flash.display.DisplayObject;
-import flash.geom.Point;
-import flash.geom.Rectangle;
+
+import openfl.geom.Matrix;
+import openfl.display.Bitmap;
+import openfl.display.DisplayObject;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
 
 /**
  * Static tile for TileLayer
@@ -177,8 +178,8 @@ class TileSprite extends TileBase
 				var cos = Math.cos(rotation);
 				var sin = Math.sin(rotation);
 				_transform[0] = dirX * cos * sx;
-				_transform[1] = dirX * sin * sx;
-				_transform[2] = -dirY * sin * sy;
+				_transform[1] = -dirY * sin * sy;
+				_transform[2] = dirX * sin * sx;
 				_transform[3] = dirY * cos * sy;
 			}
 			else {
@@ -202,7 +203,6 @@ class TileSprite extends TileBase
 			var tileHeight = height / 2;
 			var m = _matrix;
 			m.identity();
-			if (offset != null) m.translate(-offset.x, -offset.y);
 			if (layer.useTransforms) {
 				m.scale(scaleX * layer.tilesheet.scale, scaleY * layer.tilesheet.scale);
 				if (mirror != 0) {

--- a/haxelib/aze/display/TilesheetEx.hx
+++ b/haxelib/aze/display/TilesheetEx.hx
@@ -1,9 +1,10 @@
 package aze.display;
 
-import flash.display.BitmapData;
+import openfl.Assets;
+import openfl.display.BitmapData;
 import openfl.display.Tilesheet;
-import flash.geom.Point;
-import flash.geom.Rectangle;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
 
 using StringTools;
 
@@ -22,13 +23,7 @@ class TilesheetEx extends Tilesheet
 	public var scale:Float;
 	var defs:Array<String>;
 	var sizes:Array<Rectangle>;
-
-	#if haxe3
-		var anims:Map<String,Array<Int>>;
-	#else
-		var anims:Hash<Array<Int>>;
-	#end
-
+	var anims:Map<String, Array<Int>>;
 	#if flash
 	var bmps:Array<BitmapData>;
 	#end
@@ -36,17 +31,10 @@ class TilesheetEx extends Tilesheet
 	public function new(img:BitmapData, textureScale:Float = 1.0)
 	{
 		super(img);
-
-		scale = 1/textureScale;
 		
+		scale = 1/textureScale;
 		defs = new Array<String>();
-
-		#if haxe3
-			anims = new Map < String, Array<Int> > ();
-		#else
-			anims = new Hash <Array<Int> > ();
-		#end
-
+		anims = new Map<String, Array<Int>>();
 		sizes = new Array<Rectangle>();
 		#if flash
 		bmps = new Array<BitmapData>();
@@ -65,6 +53,15 @@ class TilesheetEx extends Tilesheet
 	{
 		defs.push(name);
 		sizes.push(size);
+		if (scale != 1.0)
+		{
+			rect.x /= scale;
+			rect.y /= scale;
+			rect.width /= scale;
+			rect.height /= scale;
+			center.x /= scale;
+			center.y /= scale;
+		}
 		addTileRect(rect, center);
 	}
 	#end
@@ -80,6 +77,9 @@ class TilesheetEx extends Tilesheet
 				indices.push(i);
 		}
 		anims.set(name, indices);
+		if (indices.length == 0) {
+			trace("Tilesheet has no tile with name \"" + name + "\"");
+		}
 		return indices;
 	}
 
@@ -103,7 +103,7 @@ class TilesheetEx extends Tilesheet
 		for(fileName in fileNames)
 		{
 			var name = fileName.split("/").pop();
-			var image = openfl.Assets.getBitmapData(fileName);
+			var image = Assets.getBitmapData(fileName);
 			names.push(name);
 			images.push(image);
 		}
@@ -149,3 +149,5 @@ class TilesheetEx extends Tilesheet
 		return p;
 	}
 }
+
+

--- a/haxelib/aze/display/TilesheetEx.hx
+++ b/haxelib/aze/display/TilesheetEx.hx
@@ -77,9 +77,13 @@ class TilesheetEx extends Tilesheet
 				indices.push(i);
 		}
 		anims.set(name, indices);
+
+		#if debug
 		if (indices.length == 0) {
 			trace("Tilesheet has no tile with name \"" + name + "\"");
 		}
+		#end 
+		
 		return indices;
 	}
 


### PR DESCRIPTION
Update to use OpenFL imports instead of Flash.
Fix for Flash and HTML5 of TileGroup child visibility.
Fixes for Flash of TileSprite child visibility, offset,
Fixes for other targets of offset, pivot, rotation, texture scale
Also added a trace when trying to add a tile which doesn't exist in the tilesheet, so the developer can see which one is missing.

Authors: @elsassph, Joshua Granick