### PR TITLE
allow top left center instead of center of tile

### DIFF
--- a/haxelib/aze/display/SparrowTilesheet.hx
+++ b/haxelib/aze/display/SparrowTilesheet.hx
@@ -50,7 +50,7 @@ class SparrowTilesheet extends TilesheetEx
 			bmp.copyPixels(img, rect, ins);
 			addDefinition(name, size, bmp);
 			#else
-			var center = useCenterPoint ? new Point((size.x + size.width / 2), (size.y + size.height / 2)) : null;
+			var center = useCenterPoint ? new Point((size.x + size.width / 2), (size.y + size.height / 2)) : (texture.has.frameX ? new Point(size.x, size.y) : null);
 			addDefinition(name, size, rect, center);
 			#end
 		}

--- a/haxelib/aze/display/SparrowTilesheet.hx
+++ b/haxelib/aze/display/SparrowTilesheet.hx
@@ -15,7 +15,14 @@ parrow spritesheet parser for TileLayer
 class SparrowTilesheet extends TilesheetEx
 {
 
-	public function new(img:BitmapData, xml:String, textureScale:Float = 1.0) 
+	/**
+	 * 
+	 * @param	img texture atlas
+	 * @param	xml
+	 * @param	textureScale
+	 * @param	useCenterPoint default value = true, false means that the center point will be top left
+	 */
+	public function new(img:BitmapData, xml:String, textureScale:Float = 1.0, useCenterPoint:Bool = true) 
 	{
 		super(img, textureScale);
 		
@@ -43,7 +50,7 @@ class SparrowTilesheet extends TilesheetEx
 			bmp.copyPixels(img, rect, ins);
 			addDefinition(name, size, bmp);
 			#else
-			var center = new Point((size.x + size.width / 2), (size.y + size.height / 2));
+			var center = useCenterPoint ? new Point((size.x + size.width / 2), (size.y + size.height / 2)) : null;
 			addDefinition(name, size, rect, center);
 			#end
 		}

--- a/haxelib/aze/display/SparrowTilesheet.hx
+++ b/haxelib/aze/display/SparrowTilesheet.hx
@@ -50,7 +50,10 @@ class SparrowTilesheet extends TilesheetEx
 			bmp.copyPixels(img, rect, ins);
 			addDefinition(name, size, bmp);
 			#else
-			var center = useCenterPoint ? new Point((size.x + size.width / 2), (size.y + size.height / 2)) : (texture.has.frameX ? new Point(size.x, size.y) : null);
+			var center = if (useCenterPoint)
+							new Point((size.x + size.width / 2), (size.y + size.height / 2)) 
+						else
+							texture.has.frameX ? new Point(size.x, size.y) : null;
 			addDefinition(name, size, rect, center);
 			#end
 		}

--- a/haxelib/aze/display/TilesheetEx.hx
+++ b/haxelib/aze/display/TilesheetEx.hx
@@ -100,7 +100,14 @@ class TilesheetEx extends Tilesheet
 	}
 	#end
 
-	static public function createFromAssets(fileNames:Array<String>, padding:Int=0, spacing:Int=0)
+	/**
+	 * 
+	 * @param	fileNames
+	 * @param	padding
+	 * @param	spacing
+	 * @param	useCenterPoint default value = true, false means that the center point will be top left
+	 */
+	static public function createFromAssets(fileNames:Array<String>, padding:Int=0, spacing:Int=0, useCenterPoint:Bool = true) 
 	{
 		var names:Array<String> = [];
 		var images:Array<BitmapData> = [];
@@ -111,10 +118,18 @@ class TilesheetEx extends Tilesheet
 			names.push(name);
 			images.push(image);
 		}
-		return createFromImages(names, images, padding, spacing);
+		return createFromImages(names, images, padding, spacing, useCenterPoint);
 	}
 
-	static public function createFromImages(names:Array<String>, images:Array<BitmapData>, padding:Int=0, spacing:Int=0)
+	/**
+	 * 
+	 * @param	names
+	 * @param	images
+	 * @param	padding
+	 * @param	spacing
+	 * @param	useCenterPoint default value = true, false means that the center point will be top left
+	 */
+	static public function createFromImages(names:Array<String>, images:Array<BitmapData>, padding:Int=0, spacing:Int=0, useCenterPoint:Bool = true) 
 	{
 		var width = 0;
 		var height = padding;
@@ -138,7 +153,7 @@ class TilesheetEx extends Tilesheet
 			sheet.addDefinition(names[i], image.rect, image);
 			#else
 			var rect = new Rectangle(padding, pos.y, image.width, image.height);
-			var center = new Point(image.width/2, image.height/2);
+			var center = useCenterPoint ? new Point(image.width/2, image.height/2) : null;
 			sheet.addDefinition(names[i], image.rect, rect, center);
 			#end
 			pos.y += image.height + spacing;


### PR DESCRIPTION
I use tiles with width and height of 75. So when I want to put them all together, I have a transparent pixel between them on Windows target because center point is not a fixed value (75/2=37.5).

So I allow user to set the center point on top left because center point is always a fixed value.

This is the result (first image uses center point, second image uses top left point).
![Preview of the pull request about center tile](http://s11.postimg.org/ypu7vycqb/tilelayer_bug_fix.png)
