### PR TITLE
alternative method to find a image index

### DIFF
--- a/haxelib/aze/display/TileSprite.hx
+++ b/haxelib/aze/display/TileSprite.hx
@@ -57,8 +57,7 @@ class TileSprite extends TileBase
 	override public function init(layer:TileLayer):Void
 	{
 		this.layer = layer;
-		var indices = layer.tilesheet.getAnim(tile);
-		indice = indices[0];
+		indice = layer.tilesheet.getIndex(tile);
 		size = layer.tilesheet.getSize(indice);
 	}
 

--- a/haxelib/aze/display/TilesheetEx.hx
+++ b/haxelib/aze/display/TilesheetEx.hx
@@ -89,15 +89,17 @@ class TilesheetEx extends Tilesheet
 	
 	public function getIndex(name:String):Int
 	{
-		for (i in 0...defs.length)
-		{
-			if (defs[i] == name) 
-				return i;
-		}
+		if (anims.exists(name))
+			return anims.get(name)[0];
+		var index:Int = defs.indexOf(name);
+		anims.set(name, [index]);
+		
 		#if debug
-		trace("Tilesheet has no tile with name \"" + name + "\"");
+		if(index == -1)
+			trace("Tilesheet has no tile with name \"" + name + "\"");
 		#end 
-		return -1;
+		
+		return index;
 	}
 
 	inline public function getSize(indice:Int):Rectangle

--- a/haxelib/aze/display/TilesheetEx.hx
+++ b/haxelib/aze/display/TilesheetEx.hx
@@ -24,6 +24,7 @@ class TilesheetEx extends Tilesheet
 	var defs:Array<String>;
 	var sizes:Array<Rectangle>;
 	var anims:Map<String, Array<Int>>;
+	var tiles:Map<String, Int>;
 	#if flash
 	var bmps:Array<BitmapData>;
 	#end
@@ -35,6 +36,7 @@ class TilesheetEx extends Tilesheet
 		scale = 1/textureScale;
 		defs = new Array<String>();
 		anims = new Map<String, Array<Int>>();
+		tiles = new Map<String, Int>();
 		sizes = new Array<Rectangle>();
 		#if flash
 		bmps = new Array<BitmapData>();
@@ -89,10 +91,10 @@ class TilesheetEx extends Tilesheet
 	
 	public function getIndex(name:String):Int
 	{
-		if (anims.exists(name))
-			return anims.get(name)[0];
+		if (tiles.exists(name))
+			return tiles.get(name);
 		var index:Int = defs.indexOf(name);
-		anims.set(name, [index]);
+		tiles.set(name, index);
 		
 		#if debug
 		if(index == -1)

--- a/haxelib/aze/display/TilesheetEx.hx
+++ b/haxelib/aze/display/TilesheetEx.hx
@@ -86,6 +86,19 @@ class TilesheetEx extends Tilesheet
 		
 		return indices;
 	}
+	
+	public function getIndex(name:String):Int
+	{
+		for (i in 0...defs.length)
+		{
+			if (defs[i] == name) 
+				return i;
+		}
+		#if debug
+		trace("Tilesheet has no tile with name \"" + name + "\"");
+		#end 
+		return -1;
+	}
 
 	inline public function getSize(indice:Int):Rectangle
 	{


### PR DESCRIPTION
getAnim is more relevant for TileClip, but for TileSprite we should use this alternative to get only the needed index and not an array of index
